### PR TITLE
chore: release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/sqsh-rs/CHANGELOG.md
+++ b/sqsh-rs/CHANGELOG.md
@@ -7,6 +7,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0](https://github.com/Dr-Emann/sqsh-rs/releases/tag/sqsh-rs-v0.1.0) - 2024-08-01
-
-First release of the sqsh-rs crate

--- a/sqsh-rs/CHANGELOG.md
+++ b/sqsh-rs/CHANGELOG.md
@@ -7,3 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0](https://github.com/Dr-Emann/sqsh-rs/releases/tag/sqsh-rs-v0.1.0) - 2024-08-01
+
+### Other
+- try to fix release
+- cleanup changelog
+- release
+- Publishing prep
+- Rexport source
+- seal Source trait
+- custom error type for unknown xattr types
+- xattr entry borrows iterator directly
+- Stack alocated cstr when possible
+- clippy suggestions
+- some path_resolver tests and new methods
+- not all mode_t are u16
+- Add traverse::Entry::file_type
+- High level traverse bindings
+- Update to 1.4.0 of libsqsh
+- Rename tree walker to path resolver
+- Update libsqsh
+- Use a lifetime for the archive rather than a type
+- Make archive generic over a source type
+- Add test for compression options
+- Add compression options
+- Add skip method on file reader
+- Expose compression type in superblock
+- Use options for optional superblock fields
+- Return an 'entry' from xattr iteration
+- Use consistent lifetime param names
+- Introduce Inode type
+- Transpose Option<Result>
+- implement id_table get
+- Add example for non-recursive iteration
+- Correct lifetimes of iterators
+- walker clarifications
+- Add recursive list example
+- return an 'entry' type from directory iterator
+- misc
+- Initial commit
+

--- a/sqsh-sys/CHANGELOG.md
+++ b/sqsh-sys/CHANGELOG.md
@@ -6,3 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0](https://github.com/Dr-Emann/sqsh-rs/releases/tag/sqsh-sys-v0.2.0) - 2024-08-01
+
+### Other
+- try to fix release
+- cleanup changelog
+- release
+- Publishing prep
+- Much prettier sys bindings
+- Rexport source
+- clippy suggestions
+- Properly support compressors
+- Redo how bindings are done
+- Update to 1.4.0 of libsqsh
+- Update libsqsh
+- misc
+- Update submodule
+- Initial commit

--- a/sqsh-sys/CHANGELOG.md
+++ b/sqsh-sys/CHANGELOG.md
@@ -6,7 +6,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.2.0](https://github.com/Dr-Emann/sqsh-rs/releases/tag/sqsh-sys-v0.2.0) - 2024-08-01
-
-First release of the sqsh-sys crate


### PR DESCRIPTION
## 🤖 New release
* `sqsh-sys`: 0.2.0
* `sqsh-rs`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `sqsh-sys`
<blockquote>

## [0.2.0](https://github.com/Dr-Emann/sqsh-rs/releases/tag/sqsh-sys-v0.2.0) - 2024-08-01

### Other
- try to fix release
- cleanup changelog
- release
- Publishing prep
- Much prettier sys bindings
- Rexport source
- clippy suggestions
- Properly support compressors
- Redo how bindings are done
- Update to 1.4.0 of libsqsh
- Update libsqsh
- misc
- Update submodule
- Initial commit
</blockquote>

## `sqsh-rs`
<blockquote>

## [0.1.0](https://github.com/Dr-Emann/sqsh-rs/releases/tag/sqsh-rs-v0.1.0) - 2024-08-01

### Other
- try to fix release
- cleanup changelog
- release
- Publishing prep
- Rexport source
- seal Source trait
- custom error type for unknown xattr types
- xattr entry borrows iterator directly
- Stack alocated cstr when possible
- clippy suggestions
- some path_resolver tests and new methods
- not all mode_t are u16
- Add traverse::Entry::file_type
- High level traverse bindings
- Update to 1.4.0 of libsqsh
- Rename tree walker to path resolver
- Update libsqsh
- Use a lifetime for the archive rather than a type
- Make archive generic over a source type
- Add test for compression options
- Add compression options
- Add skip method on file reader
- Expose compression type in superblock
- Use options for optional superblock fields
- Return an 'entry' from xattr iteration
- Use consistent lifetime param names
- Introduce Inode type
- Transpose Option<Result>
- implement id_table get
- Add example for non-recursive iteration
- Correct lifetimes of iterators
- walker clarifications
- Add recursive list example
- return an 'entry' type from directory iterator
- misc
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).