### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "sqsh-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitflags",
  "bstr",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "sqsh-sys"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cc",
  "libc",

--- a/sqsh-rs/CHANGELOG.md
+++ b/sqsh-rs/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/Dr-Emann/sqsh-rs/compare/sqsh-rs-v0.1.0...sqsh-rs-v0.1.1) - 2024-08-01
+
+### Added
+- impl From<sqsh::Error> for std::io::Error
+
+### Fixed
+- avoid deprecated sqsh_xattr_iterator_value_size fn
+
+### Other
+- Add readme, with example test
+- release
+
 ## [0.1.0](https://github.com/Dr-Emann/sqsh-rs/releases/tag/sqsh-rs-v0.1.0) - 2024-08-01
 
 ### Other

--- a/sqsh-rs/Cargo.toml
+++ b/sqsh-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqsh-rs"
 description = "A Rust wrapper around the libsqsh library"
-version = "0.1.0"
+version = "0.1.1"
 license = "BSD-2-Clause"
 authors = ["Zachary Dremann <dremann@gmail.com>"]
 categories = ["api-bindings"]

--- a/sqsh-sys/CHANGELOG.md
+++ b/sqsh-sys/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/Dr-Emann/sqsh-rs/compare/sqsh-sys-v0.2.0...sqsh-sys-v0.2.1) - 2024-08-01
+
+### Other
+- release
+
 ## [0.2.0](https://github.com/Dr-Emann/sqsh-rs/releases/tag/sqsh-sys-v0.2.0) - 2024-08-01
 
 ### Other

--- a/sqsh-sys/Cargo.toml
+++ b/sqsh-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqsh-sys"
 description = "Low-level bindings to the libsqsh library"
-version = "0.2.0"
+version = "0.2.1"
 license = "BSD-2-Clause"
 authors = ["Zachary Dremann <dremann@gmail.com>"]
 categories = ["external-ffi-bindings", "no-std"]


### PR DESCRIPTION
## 🤖 New release
* `sqsh-sys`: 0.2.0 -> 0.2.1
* `sqsh-rs`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `sqsh-sys`
<blockquote>

## [0.2.1](https://github.com/Dr-Emann/sqsh-rs/compare/sqsh-sys-v0.2.0...sqsh-sys-v0.2.1) - 2024-08-01

### Other
- release
</blockquote>

## `sqsh-rs`
<blockquote>

## [0.1.1](https://github.com/Dr-Emann/sqsh-rs/compare/sqsh-rs-v0.1.0...sqsh-rs-v0.1.1) - 2024-08-01

### Added
- impl From<sqsh::Error> for std::io::Error

### Fixed
- avoid deprecated sqsh_xattr_iterator_value_size fn

### Other
- Add readme, with example test
- release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).