### PR TITLE
Fix optimize lifetimes and fix Sync marker

### DIFF
--- a/sqsh-rs/examples/recursive_list.rs
+++ b/sqsh-rs/examples/recursive_list.rs
@@ -2,7 +2,7 @@ use bstr::{BStr, ByteVec};
 use sqsh_rs::{Archive, DirectoryIterator};
 use std::env;
 
-fn visit_directory(path_so_far: &BStr, mut iter: DirectoryIterator<'_, '_>) -> sqsh_rs::Result<()> {
+fn visit_directory(path_so_far: &BStr, mut iter: DirectoryIterator<'_>) -> sqsh_rs::Result<()> {
     while let Some(entry) = iter.advance()? {
         let name = entry.name();
         let mut path = path_so_far.to_owned();

--- a/sqsh-rs/src/directory.rs
+++ b/sqsh-rs/src/directory.rs
@@ -1,13 +1,13 @@
-use crate::{error, File, FileType, Inode, InodeRef};
+use crate::{error, Archive, File, FileType, Inode, InodeRef};
 use bstr::BStr;
 use sqsh_sys as ffi;
 use std::ffi::c_char;
 use std::fmt;
 use std::ptr::NonNull;
 
-pub struct DirectoryIterator<'file, 'archive> {
+pub struct DirectoryIterator<'archive> {
     inner: NonNull<ffi::SqshDirectoryIterator>,
-    _marker: std::marker::PhantomData<&'file File<'archive>>,
+    _marker: std::marker::PhantomData<&'archive Archive<'archive>>,
 }
 
 #[derive(Clone, Copy)]
@@ -15,10 +15,10 @@ pub struct DirectoryEntry<'dir, 'archive> {
     inner: &'dir ffi::SqshDirectoryIterator,
     // Because 'dir is shorter (a subtype) of 'file, and we don't need 'file, we use
     // 'dir as the first parameter to DirectoryIterator
-    _marker: std::marker::PhantomData<&'dir DirectoryIterator<'dir, 'archive>>,
+    _marker: std::marker::PhantomData<&'dir DirectoryIterator<'archive>>,
 }
 
-impl<'file, 'archive> DirectoryIterator<'file, 'archive> {
+impl<'archive> DirectoryIterator<'archive> {
     pub(crate) unsafe fn new(inner: NonNull<ffi::SqshDirectoryIterator>) -> Self {
         Self {
             inner,
@@ -65,7 +65,7 @@ impl<'file, 'archive> DirectoryIterator<'file, 'archive> {
     }
 }
 
-impl Drop for DirectoryIterator<'_, '_> {
+impl Drop for DirectoryIterator<'_> {
     fn drop(&mut self) {
         unsafe {
             ffi::sqsh_directory_iterator_free(self.inner.as_ptr());

--- a/sqsh-rs/src/file.rs
+++ b/sqsh-rs/src/file.rs
@@ -262,4 +262,3 @@ impl<'archive> Drop for File<'archive> {
 }
 
 unsafe impl<'archive> Send for File<'archive> {}
-unsafe impl<'archive> Sync for File<'archive> {}

--- a/sqsh-rs/src/file.rs
+++ b/sqsh-rs/src/file.rs
@@ -192,7 +192,7 @@ impl<'archive> File<'archive> {
     }
 
     /// Returns an iterator over the directory entries of the file.
-    pub fn as_dir(&self) -> error::Result<DirectoryIterator<'_, 'archive>> {
+    pub fn as_dir(&self) -> error::Result<DirectoryIterator<'archive>> {
         let mut err = 0;
         let dir_iter = unsafe { ffi::sqsh_directory_iterator_new(self.inner.as_ptr(), &mut err) };
         let dir_iter = match NonNull::new(dir_iter) {
@@ -202,7 +202,7 @@ impl<'archive> File<'archive> {
         Ok(unsafe { DirectoryIterator::new(dir_iter) })
     }
 
-    pub fn xattrs(&self) -> error::Result<XattrIterator<'_>> {
+    pub fn xattrs(&self) -> error::Result<XattrIterator<'archive>> {
         let mut err = 0;
         let xattr_iter = unsafe { ffi::sqsh_xattr_iterator_new(self.inner.as_ptr(), &mut err) };
         let xattr_iter = match NonNull::new(xattr_iter) {

--- a/sqsh-rs/src/file.rs
+++ b/sqsh-rs/src/file.rs
@@ -213,7 +213,7 @@ impl<'archive> File<'archive> {
     }
 
     /// Returns a new reader for the file.
-    pub fn reader(&self) -> error::Result<Reader<'_>> {
+    pub fn reader(&self) -> error::Result<Reader<'archive>> {
         let mut err = 0;
         let iterator = unsafe { ffi::sqsh_file_iterator_new(self.inner.as_ptr(), &mut err) };
         let iterator = match NonNull::new(iterator) {
@@ -223,7 +223,7 @@ impl<'archive> File<'archive> {
         Ok(unsafe { Reader::new(iterator) })
     }
 
-    pub fn traversal(&self) -> error::Result<Traversal> {
+    pub fn traversal(&self) -> error::Result<Traversal<'archive>> {
         let mut err = 0;
         let traversal = unsafe { ffi::sqsh_tree_traversal_new(self.inner.as_ptr(), &mut err) };
         let traversal = match NonNull::new(traversal) {

--- a/sqsh-rs/src/path_resolver.rs
+++ b/sqsh-rs/src/path_resolver.rs
@@ -202,7 +202,6 @@ impl fmt::Debug for PathResolver<'_> {
 }
 
 unsafe impl<'archive> Send for PathResolver<'archive> {}
-unsafe impl<'archive> Sync for PathResolver<'archive> {}
 
 impl Drop for PathResolver<'_> {
     fn drop(&mut self) {

--- a/sqsh-rs/src/reader.rs
+++ b/sqsh-rs/src/reader.rs
@@ -99,7 +99,6 @@ impl<'archive> BufRead for Reader<'archive> {
 }
 
 unsafe impl Send for Reader<'_> {}
-unsafe impl Sync for Reader<'_> {}
 
 impl<'archive> Drop for Reader<'archive> {
     fn drop(&mut self) {

--- a/sqsh-rs/src/reader.rs
+++ b/sqsh-rs/src/reader.rs
@@ -1,17 +1,17 @@
-use crate::{error, Error, File};
+use crate::{error, Archive, Error};
 use sqsh_sys as ffi;
 use std::io;
 use std::io::BufRead;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
-pub struct Reader<'file> {
+pub struct Reader<'archive> {
     inner: NonNull<ffi::SqshFileIterator>,
     consumed: usize,
-    _marker: PhantomData<&'file File<'file>>,
+    _marker: PhantomData<&'archive Archive<'archive>>,
 }
 
-impl<'file> Reader<'file> {
+impl<'archive> Reader<'archive> {
     pub(crate) unsafe fn new(inner: NonNull<ffi::SqshFileIterator>) -> Self {
         Self {
             inner,
@@ -78,7 +78,7 @@ impl<'file> Reader<'file> {
     }
 }
 
-impl<'file> io::Read for Reader<'file> {
+impl<'archive> io::Read for Reader<'archive> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let src = self.fill_buf()?;
         let len = src.len().min(buf.len());
@@ -88,7 +88,7 @@ impl<'file> io::Read for Reader<'file> {
     }
 }
 
-impl<'file> BufRead for Reader<'file> {
+impl<'archive> BufRead for Reader<'archive> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         self.fill_buf_raw().map_err(Error::into_io_error)
     }
@@ -98,10 +98,10 @@ impl<'file> BufRead for Reader<'file> {
     }
 }
 
-unsafe impl<'file> Send for Reader<'file> {}
-unsafe impl<'file> Sync for Reader<'file> {}
+unsafe impl Send for Reader<'_> {}
+unsafe impl Sync for Reader<'_> {}
 
-impl<'file> Drop for Reader<'file> {
+impl<'archive> Drop for Reader<'archive> {
     fn drop(&mut self) {
         unsafe { ffi::sqsh_file_iterator_free(self.inner.as_ptr()) };
     }

--- a/sqsh-rs/src/xattr.rs
+++ b/sqsh-rs/src/xattr.rs
@@ -1,19 +1,19 @@
-use crate::{error, File};
+use crate::{error, Archive};
 use bstr::BStr;
 use sqsh_sys as ffi;
 use std::fmt;
 use std::ptr::NonNull;
 
-pub struct XattrIterator<'file> {
+pub struct XattrIterator<'archive> {
     inner: NonNull<ffi::SqshXattrIterator>,
-    _marker: std::marker::PhantomData<&'file File<'file>>,
+    _marker: std::marker::PhantomData<&'archive Archive<'archive>>,
 }
 
 pub struct XattrEntry<'it> {
     inner: &'it ffi::SqshXattrIterator,
 }
 
-impl<'file> XattrIterator<'file> {
+impl<'archive> XattrIterator<'archive> {
     pub(crate) unsafe fn new(inner: NonNull<ffi::SqshXattrIterator>) -> Self {
         Self {
             inner,
@@ -37,7 +37,7 @@ impl<'file> XattrIterator<'file> {
     }
 }
 
-impl<'file> XattrEntry<'file> {
+impl<'it> XattrEntry<'it> {
     /// Retrieves the prefix of the current entry.
     pub fn prefix(&self) -> &'static BStr {
         let size = unsafe { ffi::sqsh_xattr_iterator_prefix_size(self.inner) };


### PR DESCRIPTION
This PR changes the lifetimes for Iterators and Readers. They don't keep references to the File object, but only to the Archive. The file object is only used during initialization.

Also I removed the Sync trait of the path resolver, file, and the file reader. Those are not threadsafe.