### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "sqsh-rs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "bstr",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "sqsh-sys"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "cc",
  "libc",

--- a/sqsh-rs/CHANGELOG.md
+++ b/sqsh-rs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/Dr-Emann/sqsh-rs/compare/sqsh-rs-v0.2.0...sqsh-rs-v0.2.1) - 2026-02-03
+
+### Other
+
+- update to v1.5.2
+
 ## [0.2.0](https://github.com/Dr-Emann/sqsh-rs/compare/sqsh-rs-v0.1.4...sqsh-rs-v0.2.0) - 2024-08-12
 
 ### Added

--- a/sqsh-rs/Cargo.toml
+++ b/sqsh-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqsh-rs"
 description = "A Rust wrapper around the libsqsh library"
-version = "0.2.0"
+version = "0.2.1"
 license = "BSD-2-Clause"
 authors = ["Zachary Dremann <dremann@gmail.com>"]
 categories = ["api-bindings"]
@@ -25,7 +25,7 @@ zstd = ["sqsh-sys/zstd"]
 bitflags = "2.3"
 bstr = "1.5"
 libc = "0.2"
-sqsh-sys = { path = "../sqsh-sys", version = "0.2", default-features = false }
+sqsh-sys = { path = "../sqsh-sys", version = "0.3", default-features = false }
 
 [dev-dependencies]
 insta = "1.30"

--- a/sqsh-sys/CHANGELOG.md
+++ b/sqsh-sys/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/Dr-Emann/sqsh-rs/compare/sqsh-sys-v0.2.2...sqsh-sys-v0.3.0) - 2026-02-03
+
+### Other
+
+- update submodules too
+- update to v1.5.2
+
 ## [0.2.2](https://github.com/Dr-Emann/sqsh-rs/compare/sqsh-sys-v0.2.1...sqsh-sys-v0.2.2) - 2024-08-02
 
 ### Fixed

--- a/sqsh-sys/Cargo.toml
+++ b/sqsh-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqsh-sys"
 description = "Low-level bindings to the libsqsh library"
-version = "0.2.2"
+version = "0.3.0"
 license = "BSD-2-Clause"
 authors = ["Zachary Dremann <dremann@gmail.com>"]
 categories = ["external-ffi-bindings", "no-std"]


### PR DESCRIPTION



## 🤖 New release

* `sqsh-sys`: 0.2.2 -> 0.3.0 (⚠ API breaking changes)
* `sqsh-rs`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

### ⚠ `sqsh-sys` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SqshMemoryMapperImpl.init2 in /tmp/.tmpvTZkf4/sqsh-rs/sqsh-sys/src/bindings.rs:201
  field SqshMemoryMapperImpl.map2 in /tmp/.tmpvTZkf4/sqsh-rs/sqsh-sys/src/bindings.rs:209
  field SqshConfig.data_lru_size in /tmp/.tmpvTZkf4/sqsh-rs/sqsh-sys/src/bindings.rs:109
  field SqshConfig.metablock_lru_size in /tmp/.tmpvTZkf4/sqsh-rs/sqsh-sys/src/bindings.rs:111

--- failure inherent_associated_pub_const_missing: inherent impl's associated pub const removed ---

Description:
An inherent impl's associated public constant is removed or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_associated_pub_const_missing.ron

Failed in:
  SqshFileType::SQSH_FILE_TYPE_UNKNOWN, previously at /tmp/.tmpOpJzdq/sqsh-sys/src/bindings.rs:342

--- warning repr_c_plain_struct_fields_reordered: struct fields reordered in repr(C) struct ---

Description:
A public repr(C) struct had its fields reordered. This can change the struct's memory layout, possibly breaking FFI use cases that depend on field position and order.
        ref: https://doc.rust-lang.org/reference/type-layout.html#reprc-structs
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/repr_c_plain_struct_fields_reordered.ron

Failed in:
  SqshConfig._reserved moved from position 8 to 10, in /tmp/.tmpvTZkf4/sqsh-rs/sqsh-sys/src/bindings.rs:113
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `sqsh-sys`

<blockquote>

## [0.3.0](https://github.com/Dr-Emann/sqsh-rs/compare/sqsh-sys-v0.2.2...sqsh-sys-v0.3.0) - 2026-02-03

### Other

- update submodules too
- update to v1.5.2
</blockquote>

## `sqsh-rs`

<blockquote>

## [0.2.1](https://github.com/Dr-Emann/sqsh-rs/compare/sqsh-rs-v0.2.0...sqsh-rs-v0.2.1) - 2026-02-03

### Other

- update to v1.5.2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).